### PR TITLE
chore(image/git-init): bump Go toolchain to 1.26.2

### DIFF
--- a/image/git-init/go.mod
+++ b/image/git-init/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd-catalog/git-clone/git-init
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
- Update the git-init module to use Go 1.26.2