### PR TITLE
chore(go): rebuild with Go 1.26.4 to fix stdlib CVEs

### DIFF
--- a/image/git-init/go.mod
+++ b/image/git-init/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd-catalog/git-clone/git-init
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
## Why

Binaries on \`alauda-v1.1.0\` build with Go 1.26.3 and carry three stdlib CVEs:

| CVE | Severity | Fixed in |
|-----|----------|----------|
| CVE-2026-42504 | HIGH | Go 1.26.4 |
| CVE-2026-27145 | MEDIUM | Go 1.26.4 |
| CVE-2026-42507 | MEDIUM | Go 1.26.4 |

The `git-init` binary produced here is consumed downstream by **AlaudaDevops/catalog** (git-init image), which fails its Trivy gate because of these stdlib CVEs.

## What

Bump the `go` directive in `image/git-init/go.mod` from `1.26.3` to `1.26.4`.

The Alauda release workflow (`reusable-release-alauda.yaml`) uses `actions/setup-go` with `go-version-file: image/git-init/go.mod`, so bumping this directive is sufficient — the next auto-cut `-alauda-N` release will build on Go 1.26.4 and scan clean.

## Files changed

- `image/git-init/go.mod`: `go 1.26.3` → `go 1.26.4`