### PR TITLE
[WIP] feat(git-init): add -lfs flag to pull Git LFS objects (DEVOPS-44388)

### DIFF
--- a/image/git-init/git/git.go
+++ b/image/git-init/git/git.go
@@ -69,6 +69,7 @@ type FetchSpec struct {
 	HTTPSProxy                string
 	NOProxy                   string
 	SparseCheckoutDirectories string
+	LFS                       bool
 }
 
 // Fetch fetches the specified git repository at the revision into path, using the refspec to fetch if provided.
@@ -203,6 +204,14 @@ func Fetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 			return err
 		}
 	}
+	// Pull Git LFS objects last, after the working tree (and any submodules)
+	// are checked out, so the LFS-tracked files are materialised into real
+	// content instead of being left as LFS pointer files.
+	if spec.LFS {
+		if err := lfsFetch(logger, spec); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -237,6 +246,34 @@ func submoduleFetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 		return err
 	}
 	logger.Infof("Successfully initialized and updated submodules in path %s", spec.Path)
+	return nil
+}
+
+// lfsFetch downloads Git LFS objects for the checked-out revision and replaces
+// the LFS pointer files in the working tree with their real content. It runs
+// after the normal checkout so the repository, remote (origin) and credentials
+// configured by Fetch are reused verbatim — LFS traffic goes to the same remote
+// with the same auth and proxy settings. Requires the git-lfs binary to be
+// present in the image; when absent the underlying git command fails loudly
+// instead of silently leaving pointer files behind.
+func lfsFetch(logger *zap.SugaredLogger, spec FetchSpec) error {
+	if spec.Path != "" {
+		if err := os.Chdir(spec.Path); err != nil {
+			return fmt.Errorf("failed to change directory with path %s; err: %w", spec.Path, err)
+		}
+	}
+	// Install the LFS smudge/process filters into this repository's local git
+	// config only (never --global / --system): the checkout is ephemeral and
+	// runs as a non-root user, so per-repo scope is both sufficient and safe.
+	if _, err := run(logger, "", "lfs", "install", "--local"); err != nil {
+		return fmt.Errorf("failed to install git-lfs (is the git-lfs binary available in the image?): %w", err)
+	}
+	// Fetch all LFS objects referenced by the current checkout and smudge them
+	// into the working tree.
+	if _, err := run(logger, "", "lfs", "pull"); err != nil {
+		return fmt.Errorf("failed to pull git-lfs objects: %w", err)
+	}
+	logger.Infof("Successfully pulled git-lfs objects in path %s", spec.Path)
 	return nil
 }
 

--- a/image/git-init/main.go
+++ b/image/git-init/main.go
@@ -37,6 +37,7 @@ func init() {
 	flag.BoolVar(&fetchSpec.SSLVerify, "sslVerify", true, "Enable/Disable SSL verification in the git config")
 	flag.BoolVar(&fetchSpec.Submodules, "submodules", true, "Initialize and fetch Git submodules")
 	flag.UintVar(&fetchSpec.Depth, "depth", 1, "Perform a shallow clone to this depth")
+	flag.BoolVar(&fetchSpec.LFS, "lfs", false, "Pull Git LFS objects after checkout (requires git-lfs in the image)")
 	flag.StringVar(&terminationMessagePath, "terminationMessagePath", "/tekton/termination", "Location of file containing termination message")
 	flag.StringVar(&fetchSpec.SparseCheckoutDirectories, "sparseCheckoutDirectories", "", "String of directory patterns separated by a comma")
 }


### PR DESCRIPTION
> **Status: WIP / incomplete — opened as a reference for the next implementation of DEVOPS-44388. NOT ready to merge.**

## What this does
Adds opt-in Git LFS support to `git-init` so the `git-clone` Task can materialise LFS-tracked files into their real content instead of leaving LFS pointer files in the working tree.

- New `-lfs` flag (default `false`) in `main.go`.
- `FetchSpec.LFS` + `lfsFetch()` in `git/git.go`: after checkout (including submodules), run `git lfs install --local` then `git lfs pull`, reusing the already-configured `origin`, credentials and proxy settings.

## Verified locally
- `go vet` / `go build` / existing unit tests all green.
- Integration test against a real LFS repository: with `-lfs=true` the working tree gets the real object content (sha256 matches the source), exit 0; with `-lfs=false` (default) the file stays an LFS pointer — behaviour byte-for-byte unchanged.
- The base image `cgr.dev/chainguard/git` already ships `git-lfs` (3.7.1), so no base-image change is required.

## NOT done yet (why this is WIP)
- [ ] No repo-level unit test added for the LFS path (`git/git_test.go`) — only an external integration test was run.
- [ ] git-init image not yet rebuilt / published with this code.
- [ ] No cluster e2e run.

## Rollout ordering (important)
The git-init **image must be rebuilt and published first**; only then can the catalog `git-clone` Task's `lfs=true` work in-cluster. Passing `-lfs` to an image that predates this flag fails (Go's flag parser exits non-zero). The companion Task change already guards against this by only appending `-lfs` when explicitly enabled.

## Context
- Companion Task wiring PR (catalog `git-clone` Task): tracked in the Jira ticket below.
- Jira: DEVOPS-44388
